### PR TITLE
improved loading function at LOSTDataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - dependencies for lost_ds in requirements.txt + setup.py
+- examples dataset and code-snippets
+- improved function to load datasets at LOSTDataset
 ## [0.0.0] - 2021-10-26
 ### Added
 - First version

--- a/lost_ds/core.py
+++ b/lost_ds/core.py
@@ -63,11 +63,11 @@ class LOSTDataset(object):
         ''' Initialize LOSTDataset
         
         Args:
-            ds (str, list of str, pd.DataFrame, list of pd.DataFrame): 
-                Dataset(s) to use. Either path(s) or pd.DataFrame instance(s)
+            ds (str, pd.DataFrame, LOSTDataset, list(s)): 
+                Dataset(s) to use. The different types can be combined in lists.
             filesystem (fsspec.filesystem, None): Filesystem to use. If None the 
                 local filesystem will be used.
-                
+            
         '''
         self.fileman = FileMan(filesystem)
         self.df = self.fileman.load_dataset(ds)

--- a/lost_ds/io/file_man.py
+++ b/lost_ds/io/file_man.py
@@ -128,17 +128,19 @@ class FileMan(object):
     
     
     def load_dataset(self, ds):
+        
         if isinstance(ds, str):
             return self._load_dataset(ds)
         elif isinstance(ds, pd.DataFrame):
             return ds
-        elif isinstance(ds, list):
-            if isinstance(ds[0], str):
-                return pd.concat([self._load_dataset(path) for path in ds])
-            elif isinstance(ds[0], pd.DataFrame):
-                return pd.concat(ds)
         elif 'LOSTDataset' in str(type(ds)):
             return ds.df
+        elif ds is None:
+            return None
+        elif isinstance(ds, list):
+            return pd.concat([self.load_dataset(df) for df in ds])
+        else:
+            raise ValueError('Unkown input-type {}'.format(type(ds)))
             
             
     def _load_dataset(self, ds_path):


### PR DESCRIPTION
When loading LOSTDataset(ds), a ds can now be pd.DataFrame, string, LOSTDataset, list or list of any types in undefinded order - e.g. [pd.DataFrame, str, [str, LOSTDataset]]
